### PR TITLE
Change url in NPU codesystem to supersede the dk core system

### DIFF
--- a/input/fsh/NPUObservationCodes.fsh
+++ b/input/fsh/NPUObservationCodes.fsh
@@ -5,8 +5,7 @@ Description: "CodeSystem with NPU observation codes"
 * ^status = #draft
 * ^date = "2025-06-28"
 * ^caseSensitive = false
-* ^experimental = true
-* ^identifier[+].value = "urn:oid:1.2.208.176.2.1"
+* ^url = "urn:oid:1.2.208.176.2.1"
 * ^language = #da-DK
 
 * ^property[+].code = #status
@@ -340,6 +339,5 @@ Description: "ValuseSet with NPU observations Codes"
 * ^version = "1.0.0"
 * ^status = #draft
 * ^date = "2025-06-28"
-* ^experimental = true
 * include codes from system npu-observation-codes
 


### PR DESCRIPTION
We pretty much always depend on hl7 dk core which has a NPU code system with only the most basic codes.
We have our own NPU system in terminology, which we would like to utilize instead in most cases...